### PR TITLE
Skip no ScheduleExpression

### DIFF
--- a/src/lib/rules_parser.ts
+++ b/src/lib/rules_parser.ts
@@ -28,7 +28,7 @@ export class RulesParser {
   static parse(rules: AWSEvent["Rules"]) {
     const parsedRules: Rule[] = []
     for (const rule of rules) {
-      if (rule.State == "DISABLED") {
+      if (rule.State == "DISABLED" || !rule.ScheduleExpression) {
         continue
       }
       const schedule = awsCronParser.parse(this.extractCronPattern(rule.ScheduleExpression))


### PR DESCRIPTION
I think no need to process rules for which ScheduleExpression does not exist.

```
node_modules/aws-cronv/dist/lib/rules_parser.js:24
        return scheduleExpression.replace("cron(", "").replace(")", "");
                                  ^

TypeError: Cannot read properties of undefined (reading 'replace')
    at Function.extractCronPattern (node_modules/aws-cronv/dist/lib/rules_parser.js:24:35)
    at Function.parse (node_modules/aws-cronv/dist/lib/rules_parser.js:15:67)
    at main (node_modules/aws-cronv/dist/index.js:13:46)
    at Object.<anonymous> (node_modules/aws-cronv/dist/index.js:18:1)
```