### PR TITLE
Fixed google.visualization.DataTable error with empty elements.

### DIFF
--- a/src/lib/template.ts
+++ b/src/lib/template.ts
@@ -2,7 +2,7 @@ import { Schedule } from "./schedule_builder"
 
 export class Template {
   static build(schedule: Schedule) {
-    const rows = Object.keys(schedule).map(name => schedule[name].map(timestamp => `['${name}', new Date(${timestamp}), new Date(${timestamp})]`).join())
+    const rows = Object.keys(schedule).map(name => schedule[name].map(timestamp => `['${name}', new Date(${timestamp}), new Date(${timestamp})]`).join()).filter(e => e);
     return `
     <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
 


### PR DESCRIPTION
```
jsapi_compiled_default_module.js:294 Uncaught (in promise) Error: Row 2 is not null or an array.
    at gvjs_.G_ (jsapi_compiled_default_module.js:294:238)
    at gvjs_.Yn (jsapi_compiled_default_module.js:295:73)
    at events.html:15:19
```